### PR TITLE
fix(spacelift): drop spacelift-git-use-https, unneeded since K8s Spacelift Workers

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -7,6 +7,5 @@ test_defaults:
 
   before_init:
     - spacelift-configure-paths
-    - spacelift-git-use-https
 
 tests: []


### PR DESCRIPTION
## what

- Drop `spacelift-git-use-https` from `.spacelift/config.yml`'s `before_init` list.

## why

- This step was needed for the old Spacelift worker setup and is now obsolete since moving to K8s Spacelift Workers. Same fix as BrightDotAi/terraform-auth0-native-client#16.

## references

- N/A